### PR TITLE
Unity Mole Fraction & MFR Issue

### DIFF
--- a/Assets/Scripts/Communication/CommClient.cs
+++ b/Assets/Scripts/Communication/CommClient.cs
@@ -462,7 +462,7 @@ namespace Rochester.ARTable.Communication
             for (int i = 0; i < chemical_species_list.Length; i++)
             {
                 string chem_spec_str = "Backend/ColorKey/Species" + i + "Text";
-                chemical_species = GameObject.Find(chem_spec_str)
+                chemical_species = GameObject.Find(chem_spec_str);
                 chemical_species.GetComponent<Text>().text = System.String.Format(chemical_species_list[i]);
             }
 

--- a/Assets/Scripts/Communication/CommClient.cs
+++ b/Assets/Scripts/Communication/CommClient.cs
@@ -11,6 +11,7 @@ using UnityEngine.SceneManagement;
 using UnityEngine.UI;
 using Rochester.ARTable.Particles;
 using System.Linq;
+using Rochester.ARTable.Structures;
 
 namespace Rochester.ARTable.Communication
 {
@@ -472,12 +473,13 @@ namespace Rochester.ARTable.Communication
             timeValue.GetComponent<Text>().text = System.String.Format("{0:0.00} s", system_time);
             foreach(var rxr in kinetics.Kinetics)
             {
+                var reactor = new Reactor();
                 var currentObjs = managedObjects["reactor"];
                 GameObject existing;
                 currentObjs.TryGetValue( rxr.Id, out existing);
                 if(existing)
                 {
-                    //rend = existing.GetComponent<MeshRenderer>();
+                    rend = existing.GetComponent<Renderer>();
                     //rend.material.shader = Shader.Find("Custom/WedgeCircle");
                     count = 0;
                     sum = 0;
@@ -494,8 +496,8 @@ namespace Rochester.ARTable.Communication
                         {
                         //rend.material.SetFloat("_Fraction" + (i + 1).ToString(), value: (rxr.MoleFraction[i]));
                         //rend.material.SetFloat("_FlowRate" + (i + 1).ToString(), value: (rxr.MolarFlowRate[i]));
-                        rend.material.set_molefrac(i, rxr.MoleFraction[i])
-                        rend.material.set_flowrate(i, rxr.MolarFlowRate[i])
+                        reactor.set_molefrac(i, rxr.MoleFraction[i]);
+                        reactor.set_flowrate(i, rxr.MolarFlowRate[i]);
                         }
                     }
                     else
@@ -505,11 +507,11 @@ namespace Rochester.ARTable.Communication
                         {
                             //rend.material.SetFloat("_Fraction" + (i + 1).ToString(), value: ((float)0));
                             //rend.material.SetFloat("_FlowRate" + (i+1).ToString(), value: ((float)0));
-                            rend.material.set_molefrac(i, (float)0)
-                            rend.material.set_flowrate(i, (float)0)
+                            reactor.set_molefrac(i, (float)0);
+                            reactor.set_flowrate(i, (float)0);
                         }
                         //rend.material.SetFloat("_Fraction5", value: ((float)1));
-                        set_flowrate(5, (float)1)
+                        reactor.set_flowrate(5, (float)1);
                     }
                 }
                 else

--- a/Assets/Scripts/Communication/CommClient.cs
+++ b/Assets/Scripts/Communication/CommClient.cs
@@ -256,6 +256,7 @@ namespace Rochester.ARTable.Communication
             }
             return managedObjects[label];
         }
+        
         private void synchronizeGraph(Graph system)
         {
             foreach(var key in system.Nodes.Keys)
@@ -490,7 +491,7 @@ namespace Rochester.ARTable.Communication
                     }
                     if(sum > 0 && sum <= 1.0)
                     {
-                        rend.material.SetInt("_NumWedges", value:count);
+                        reactor.set_numwedges(rend, count);
                         for (int i = 0; i < count; i++)
                         {
                         reactor.set_molefrac(i, rend, rxr.MoleFraction[i]);
@@ -499,7 +500,7 @@ namespace Rochester.ARTable.Communication
                     }
                     else
                     {
-                        rend.material.SetInt("_NumWedges", value:5);
+                        reactor.set_numwedges(rend, 5);
                         for (int i = 0; i < count; i++)
                         {
                             reactor.set_molefrac(i, rend, (float)0);

--- a/Assets/Scripts/Communication/CommClient.cs
+++ b/Assets/Scripts/Communication/CommClient.cs
@@ -479,8 +479,7 @@ namespace Rochester.ARTable.Communication
                 currentObjs.TryGetValue( rxr.Id, out existing);
                 if(existing)
                 {
-                    rend = existing.GetComponent<Renderer>();
-                    //rend.material.shader = Shader.Find("Custom/WedgeCircle");
+                    rend = existing.GetComponent<MeshRenderer>();
                     count = 0;
                     sum = 0;
                     foreach (var molefrac in rxr.MoleFraction)
@@ -494,10 +493,8 @@ namespace Rochester.ARTable.Communication
                         rend.material.SetInt("_NumWedges", value:count);
                         for (int i = 0; i < count; i++)
                         {
-                        //rend.material.SetFloat("_Fraction" + (i + 1).ToString(), value: (rxr.MoleFraction[i]));
-                        //rend.material.SetFloat("_FlowRate" + (i + 1).ToString(), value: (rxr.MolarFlowRate[i]));
-                        reactor.set_molefrac(i, rxr.MoleFraction[i]);
-                        reactor.set_flowrate(i, rxr.MolarFlowRate[i]);
+                        reactor.set_molefrac(i, rend, rxr.MoleFraction[i]);
+                        reactor.set_flowrate(i, rend, rxr.MolarFlowRate[i]);
                         }
                     }
                     else
@@ -505,13 +502,10 @@ namespace Rochester.ARTable.Communication
                         rend.material.SetInt("_NumWedges", value:5);
                         for (int i = 0; i < count; i++)
                         {
-                            //rend.material.SetFloat("_Fraction" + (i + 1).ToString(), value: ((float)0));
-                            //rend.material.SetFloat("_FlowRate" + (i+1).ToString(), value: ((float)0));
-                            reactor.set_molefrac(i, (float)0);
-                            reactor.set_flowrate(i, (float)0);
+                            reactor.set_molefrac(i, rend, (float)0);
+                            reactor.set_flowrate(i, rend, (float)0);
                         }
-                        //rend.material.SetFloat("_Fraction5", value: ((float)1));
-                        reactor.set_flowrate(5, (float)1);
+                        reactor.set_flowrate(5, rend, (float)1);
                     }
                 }
                 else

--- a/Assets/Scripts/Communication/CommClient.cs
+++ b/Assets/Scripts/Communication/CommClient.cs
@@ -457,6 +457,27 @@ namespace Rochester.ARTable.Communication
             int count;
             float sum;
             float system_time = (float)kinetics.Time / (float) 3.25;//divide by 3.25 to go from FPS to accelerated seconds
+            string[] chemical_species_list = kinetics.ChemicalSpecies;
+            
+            //The following for loop will cycle through all chemical species (from chemical_species_list) and edit the 
+            //chem_spec_str that is used later on as a command when accessing the particular species name for display via Unity.
+            for (int i=0; i < chemical_species_list.Length; i++)
+            {
+                string chem_spec_str = "Backend/ColorKey/Species#Text";
+                char[] chem_spec_array = chem_spec_str.ToCharArray();
+                for (int q=0; q < chem_spec_array.Length; q++)
+                {
+                    char letter = chem_spec_array[q];
+                    if (letter.Equals('#'))
+                    {
+                        chem_spec_array[q] = Convert.ToChar((i+1).ToString());
+                    }
+                }
+                chem_spec_str = new string(chem_spec_array);
+                chemical_species = GameObject.Find(chem_spec_str)
+                chemical_species.GetComponent<Text>().text = System.String.Format(chemical_species_list[i]);
+            }
+
             timeValue = GameObject.Find("Backend/ColorKey/TimeValue");
             timeValue.GetComponent<Text>().text = System.String.Format("{0:0.00} s", system_time);
             foreach(var rxr in kinetics.Kinetics)

--- a/Assets/Scripts/Communication/CommClient.cs
+++ b/Assets/Scripts/Communication/CommClient.cs
@@ -477,8 +477,8 @@ namespace Rochester.ARTable.Communication
                 currentObjs.TryGetValue( rxr.Id, out existing);
                 if(existing)
                 {
-                    rend = existing.GetComponent<MeshRenderer>();
-                    rend.material.shader = Shader.Find("Custom/WedgeCircle");
+                    //rend = existing.GetComponent<MeshRenderer>();
+                    //rend.material.shader = Shader.Find("Custom/WedgeCircle");
                     count = 0;
                     sum = 0;
                     foreach (var molefrac in rxr.MoleFraction)
@@ -492,8 +492,10 @@ namespace Rochester.ARTable.Communication
                         rend.material.SetInt("_NumWedges", value:count);
                         for (int i = 0; i < count; i++)
                         {
-                        rend.material.SetFloat("_Fraction" + (i + 1).ToString(), value: (rxr.MoleFraction[i]));
-                        rend.material.SetFloat("_FlowRate" + (i + 1).ToString(), value: (rxr.MolarFlowRate[i]));
+                        //rend.material.SetFloat("_Fraction" + (i + 1).ToString(), value: (rxr.MoleFraction[i]));
+                        //rend.material.SetFloat("_FlowRate" + (i + 1).ToString(), value: (rxr.MolarFlowRate[i]));
+                        rend.material.set_molefrac(i, rxr.MoleFraction[i])
+                        rend.material.set_flowrate(i, rxr.MolarFlowRate[i])
                         }
                     }
                     else
@@ -501,10 +503,13 @@ namespace Rochester.ARTable.Communication
                         rend.material.SetInt("_NumWedges", value:5);
                         for (int i = 0; i < count; i++)
                         {
-                            rend.material.SetFloat("_Fraction" + (i + 1).ToString(), value: ((float)0));
-                            rend.material.SetFloat("_FlowRate" + (i+1).ToString(), value: ((float)0));
+                            //rend.material.SetFloat("_Fraction" + (i + 1).ToString(), value: ((float)0));
+                            //rend.material.SetFloat("_FlowRate" + (i+1).ToString(), value: ((float)0));
+                            rend.material.set_molefrac(i, (float)0)
+                            rend.material.set_flowrate(i, (float)0)
                         }
-                        rend.material.SetFloat("_Fraction5", value: ((float)1));
+                        //rend.material.SetFloat("_Fraction5", value: ((float)1));
+                        set_flowrate(5, (float)1)
                     }
                 }
                 else

--- a/Assets/Scripts/Communication/CommClient.cs
+++ b/Assets/Scripts/Communication/CommClient.cs
@@ -459,21 +459,9 @@ namespace Rochester.ARTable.Communication
             float system_time = (float)kinetics.Time / (float) 3.25;//divide by 3.25 to go from FPS to accelerated seconds
             string[] chemical_species_list = kinetics.ChemicalSpecies;
             
-            //The following for loop will cycle through all chemical species (from chemical_species_list) and edit the 
-            //chem_spec_str that is used later on as a command when accessing the particular species name for display via Unity.
-            for (int i=0; i < chemical_species_list.Length; i++)
+            for (int i = 0; i < chemical_species_list.Length; i++)
             {
-                string chem_spec_str = "Backend/ColorKey/Species#Text";
-                char[] chem_spec_array = chem_spec_str.ToCharArray();
-                for (int q=0; q < chem_spec_array.Length; q++)
-                {
-                    char letter = chem_spec_array[q];
-                    if (letter.Equals('#'))
-                    {
-                        chem_spec_array[q] = Convert.ToChar((i+1).ToString());
-                    }
-                }
-                chem_spec_str = new string(chem_spec_array);
+                string chem_spec_str = "Backend/ColorKey/Species" + i + "Text";
                 chemical_species = GameObject.Find(chem_spec_str)
                 chemical_species.GetComponent<Text>().text = System.String.Format(chemical_species_list[i]);
             }

--- a/Assets/Scripts/Communication/CommClient.cs
+++ b/Assets/Scripts/Communication/CommClient.cs
@@ -487,12 +487,13 @@ namespace Rochester.ARTable.Communication
                         sum += molefrac;
                         //test
                     }
-                    if(sum > 0)
+                    if(sum > 0 && sum <= 1.0)
                     {
                         rend.material.SetInt("_NumWedges", value:count);
                         for (int i = 0; i < count; i++)
                         {
                         rend.material.SetFloat("_Fraction" + (i + 1).ToString(), value: (rxr.MoleFraction[i]));
+                        rend.material.SetFloat("_FlowRate" + (i + 1).ToString(), value: (rxr.MolarFlowRate[i]));
                         }
                     }
                     else
@@ -501,6 +502,7 @@ namespace Rochester.ARTable.Communication
                         for (int i = 0; i < count; i++)
                         {
                             rend.material.SetFloat("_Fraction" + (i + 1).ToString(), value: ((float)0));
+                            rend.material.SetFloat("_FlowRate" + (i+1).ToString(), value: ((float)0));
                         }
                         rend.material.SetFloat("_Fraction5", value: ((float)1));
                     }

--- a/Assets/Scripts/Communication/CommClient.cs
+++ b/Assets/Scripts/Communication/CommClient.cs
@@ -33,6 +33,8 @@ namespace Rochester.ARTable.Communication
         private GameObject timeValue;
         private string timeText;
 
+        private GameObject chemical_species;
+
         private GameObject backend;
 
 
@@ -457,11 +459,11 @@ namespace Rochester.ARTable.Communication
             int count;
             float sum;
             float system_time = (float)kinetics.Time / (float) 3.25;//divide by 3.25 to go from FPS to accelerated seconds
-            string[] chemical_species_list = kinetics.ChemicalSpecies;
+            string[] chemical_species_list = kinetics.ChemicalSpecies.ToArray<string>();
             
             for (int i = 0; i < chemical_species_list.Length; i++)
             {
-                string chem_spec_str = "Backend/ColorKey/Species" + i + "Text";
+                string chem_spec_str = "Backend/ColorKey/Species" + (i+1) + "Text";
                 chemical_species = GameObject.Find(chem_spec_str);
                 chemical_species.GetComponent<Text>().text = System.String.Format(chemical_species_list[i]);
             }

--- a/Assets/Scripts/Communication/Kinetics.cs
+++ b/Assets/Scripts/Communication/Kinetics.cs
@@ -22,18 +22,18 @@ namespace Rochester.Physics.Communication {
     static KineticsReflection() {
       byte[] descriptorData = global::System.Convert.FromBase64String(
           string.Concat(
-            "Cg5raW5ldGljcy5wcm90bxIIcmVhY3RvcnMinQEKD1JlYWN0b3JLaW5ldGlj",
+            "Cg5raW5ldGljcy5wcm90bxIIcmVhY3RvcnMigwEKD1JlYWN0b3JLaW5ldGlj",
             "cxITCgt0ZW1wZXJhdHVyZRgBIAEoAhIQCghwcmVzc3VyZRgCIAEoAhINCgVs",
             "YWJlbBgDIAEoCRIKCgJpZBgEIAEoBRIVCg1tb2xlX2ZyYWN0aW9uGAUgAygC",
-            "EhgKEGNoZW1pY2FsX3NwZWNpZXMYBiADKAkSFwoPbW9sYXJfZmxvd19yYXRl",
-            "GAcgAygCIksKDlN5c3RlbUtpbmV0aWNzEgwKBHRpbWUYASABKAMSKwoIa2lu",
-            "ZXRpY3MYAiADKAsyGS5yZWFjdG9ycy5SZWFjdG9yS2luZXRpY3NCIqoCH1Jv",
+            "EhcKD21vbGFyX2Zsb3dfcmF0ZRgGIAMoAiJlCg5TeXN0ZW1LaW5ldGljcxIM",
+            "CgR0aW1lGAEgASgDEhgKEGNoZW1pY2FsX3NwZWNpZXMYAiADKAkSKwoIa2lu",
+            "ZXRpY3MYAyADKAsyGS5yZWFjdG9ycy5SZWFjdG9yS2luZXRpY3NCIqoCH1Jv",
             "Y2hlc3Rlci5QaHlzaWNzLkNvbW11bmljYXRpb25iBnByb3RvMw=="));
       descriptor = pbr::FileDescriptor.FromGeneratedCode(descriptorData,
           new pbr::FileDescriptor[] { },
           new pbr::GeneratedClrTypeInfo(null, new pbr::GeneratedClrTypeInfo[] {
-            new pbr::GeneratedClrTypeInfo(typeof(global::Rochester.Physics.Communication.ReactorKinetics), global::Rochester.Physics.Communication.ReactorKinetics.Parser, new[]{ "Temperature", "Pressure", "Label", "Id", "MoleFraction", "ChemicalSpecies", "MolarFlowRate" }, null, null, null),
-            new pbr::GeneratedClrTypeInfo(typeof(global::Rochester.Physics.Communication.SystemKinetics), global::Rochester.Physics.Communication.SystemKinetics.Parser, new[]{ "Time", "Kinetics" }, null, null, null)
+            new pbr::GeneratedClrTypeInfo(typeof(global::Rochester.Physics.Communication.ReactorKinetics), global::Rochester.Physics.Communication.ReactorKinetics.Parser, new[]{ "Temperature", "Pressure", "Label", "Id", "MoleFraction", "MolarFlowRate" }, null, null, null),
+            new pbr::GeneratedClrTypeInfo(typeof(global::Rochester.Physics.Communication.SystemKinetics), global::Rochester.Physics.Communication.SystemKinetics.Parser, new[]{ "Time", "ChemicalSpecies", "Kinetics" }, null, null, null)
           }));
     }
     #endregion
@@ -69,7 +69,6 @@ namespace Rochester.Physics.Communication {
       label_ = other.label_;
       id_ = other.id_;
       moleFraction_ = other.moleFraction_.Clone();
-      chemicalSpecies_ = other.chemicalSpecies_.Clone();
       molarFlowRate_ = other.molarFlowRate_.Clone();
     }
 
@@ -132,20 +131,10 @@ namespace Rochester.Physics.Communication {
       get { return moleFraction_; }
     }
 
-    /// <summary>Field number for the "chemical_species" field.</summary>
-    public const int ChemicalSpeciesFieldNumber = 6;
-    private static readonly pb::FieldCodec<string> _repeated_chemicalSpecies_codec
-        = pb::FieldCodec.ForString(50);
-    private readonly pbc::RepeatedField<string> chemicalSpecies_ = new pbc::RepeatedField<string>();
-    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    public pbc::RepeatedField<string> ChemicalSpecies {
-      get { return chemicalSpecies_; }
-    }
-
     /// <summary>Field number for the "molar_flow_rate" field.</summary>
-    public const int MolarFlowRateFieldNumber = 7;
+    public const int MolarFlowRateFieldNumber = 6;
     private static readonly pb::FieldCodec<float> _repeated_molarFlowRate_codec
-        = pb::FieldCodec.ForFloat(58);
+        = pb::FieldCodec.ForFloat(50);
     private readonly pbc::RepeatedField<float> molarFlowRate_ = new pbc::RepeatedField<float>();
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public pbc::RepeatedField<float> MolarFlowRate {
@@ -170,7 +159,6 @@ namespace Rochester.Physics.Communication {
       if (Label != other.Label) return false;
       if (Id != other.Id) return false;
       if(!moleFraction_.Equals(other.moleFraction_)) return false;
-      if(!chemicalSpecies_.Equals(other.chemicalSpecies_)) return false;
       if(!molarFlowRate_.Equals(other.molarFlowRate_)) return false;
       return true;
     }
@@ -183,7 +171,6 @@ namespace Rochester.Physics.Communication {
       if (Label.Length != 0) hash ^= Label.GetHashCode();
       if (Id != 0) hash ^= Id.GetHashCode();
       hash ^= moleFraction_.GetHashCode();
-      hash ^= chemicalSpecies_.GetHashCode();
       hash ^= molarFlowRate_.GetHashCode();
       return hash;
     }
@@ -212,7 +199,6 @@ namespace Rochester.Physics.Communication {
         output.WriteInt32(Id);
       }
       moleFraction_.WriteTo(output, _repeated_moleFraction_codec);
-      chemicalSpecies_.WriteTo(output, _repeated_chemicalSpecies_codec);
       molarFlowRate_.WriteTo(output, _repeated_molarFlowRate_codec);
     }
 
@@ -232,7 +218,6 @@ namespace Rochester.Physics.Communication {
         size += 1 + pb::CodedOutputStream.ComputeInt32Size(Id);
       }
       size += moleFraction_.CalculateSize(_repeated_moleFraction_codec);
-      size += chemicalSpecies_.CalculateSize(_repeated_chemicalSpecies_codec);
       size += molarFlowRate_.CalculateSize(_repeated_molarFlowRate_codec);
       return size;
     }
@@ -255,7 +240,6 @@ namespace Rochester.Physics.Communication {
         Id = other.Id;
       }
       moleFraction_.Add(other.moleFraction_);
-      chemicalSpecies_.Add(other.chemicalSpecies_);
       molarFlowRate_.Add(other.molarFlowRate_);
     }
 
@@ -288,12 +272,8 @@ namespace Rochester.Physics.Communication {
             moleFraction_.AddEntriesFrom(input, _repeated_moleFraction_codec);
             break;
           }
-          case 50: {
-            chemicalSpecies_.AddEntriesFrom(input, _repeated_chemicalSpecies_codec);
-            break;
-          }
-          case 58:
-          case 61: {
+          case 50:
+          case 53: {
             molarFlowRate_.AddEntriesFrom(input, _repeated_molarFlowRate_codec);
             break;
           }
@@ -328,6 +308,7 @@ namespace Rochester.Physics.Communication {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public SystemKinetics(SystemKinetics other) : this() {
       time_ = other.time_;
+      chemicalSpecies_ = other.chemicalSpecies_.Clone();
       kinetics_ = other.kinetics_.Clone();
     }
 
@@ -350,10 +331,20 @@ namespace Rochester.Physics.Communication {
       }
     }
 
+    /// <summary>Field number for the "chemical_species" field.</summary>
+    public const int ChemicalSpeciesFieldNumber = 2;
+    private static readonly pb::FieldCodec<string> _repeated_chemicalSpecies_codec
+        = pb::FieldCodec.ForString(18);
+    private readonly pbc::RepeatedField<string> chemicalSpecies_ = new pbc::RepeatedField<string>();
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public pbc::RepeatedField<string> ChemicalSpecies {
+      get { return chemicalSpecies_; }
+    }
+
     /// <summary>Field number for the "kinetics" field.</summary>
-    public const int KineticsFieldNumber = 2;
+    public const int KineticsFieldNumber = 3;
     private static readonly pb::FieldCodec<global::Rochester.Physics.Communication.ReactorKinetics> _repeated_kinetics_codec
-        = pb::FieldCodec.ForMessage(18, global::Rochester.Physics.Communication.ReactorKinetics.Parser);
+        = pb::FieldCodec.ForMessage(26, global::Rochester.Physics.Communication.ReactorKinetics.Parser);
     private readonly pbc::RepeatedField<global::Rochester.Physics.Communication.ReactorKinetics> kinetics_ = new pbc::RepeatedField<global::Rochester.Physics.Communication.ReactorKinetics>();
     /// <summary>
     ///repeats for all components(reactors and pipes) in the system
@@ -377,6 +368,7 @@ namespace Rochester.Physics.Communication {
         return true;
       }
       if (Time != other.Time) return false;
+      if(!chemicalSpecies_.Equals(other.chemicalSpecies_)) return false;
       if(!kinetics_.Equals(other.kinetics_)) return false;
       return true;
     }
@@ -385,6 +377,7 @@ namespace Rochester.Physics.Communication {
     public override int GetHashCode() {
       int hash = 1;
       if (Time != 0L) hash ^= Time.GetHashCode();
+      hash ^= chemicalSpecies_.GetHashCode();
       hash ^= kinetics_.GetHashCode();
       return hash;
     }
@@ -400,6 +393,7 @@ namespace Rochester.Physics.Communication {
         output.WriteRawTag(8);
         output.WriteInt64(Time);
       }
+      chemicalSpecies_.WriteTo(output, _repeated_chemicalSpecies_codec);
       kinetics_.WriteTo(output, _repeated_kinetics_codec);
     }
 
@@ -409,6 +403,7 @@ namespace Rochester.Physics.Communication {
       if (Time != 0L) {
         size += 1 + pb::CodedOutputStream.ComputeInt64Size(Time);
       }
+      size += chemicalSpecies_.CalculateSize(_repeated_chemicalSpecies_codec);
       size += kinetics_.CalculateSize(_repeated_kinetics_codec);
       return size;
     }
@@ -421,6 +416,7 @@ namespace Rochester.Physics.Communication {
       if (other.Time != 0L) {
         Time = other.Time;
       }
+      chemicalSpecies_.Add(other.chemicalSpecies_);
       kinetics_.Add(other.kinetics_);
     }
 
@@ -437,6 +433,10 @@ namespace Rochester.Physics.Communication {
             break;
           }
           case 18: {
+            chemicalSpecies_.AddEntriesFrom(input, _repeated_chemicalSpecies_codec);
+            break;
+          }
+          case 26: {
             kinetics_.AddEntriesFrom(input, _repeated_kinetics_codec);
             break;
           }

--- a/Assets/Scripts/UI/Structures/Reactor.cs
+++ b/Assets/Scripts/UI/Structures/Reactor.cs
@@ -42,15 +42,13 @@ namespace Rochester.ARTable.Structures
             temperature = temp;
         }
 
-        public void set_molefrac(int i, float mole_frac)
+        public void set_molefrac(int i, Renderer rend, float mole_frac)
         {
-            Renderer rend = this.GetComponent<Renderer>();
             rend.material.SetFloat("_Fraction" + (i+1).ToString(), value: mole_frac);
         }
 
-        public void set_flowrate (int i, float flow_rate)
+        public void set_flowrate (int i, Renderer rend, float flow_rate)
         {
-            Renderer rend = this.GetComponent<Renderer>();
             rend.material.SetFloat("_FlowRate" + (i+1).ToString(), value: flow_rate);
         }
 

--- a/Assets/Scripts/UI/Structures/Reactor.cs
+++ b/Assets/Scripts/UI/Structures/Reactor.cs
@@ -45,13 +45,13 @@ namespace Rochester.ARTable.Structures
         public void set_molefrac(int i, float mole_frac)
         {
             Renderer rend = this.GetComponent<Renderer>();
-            rend.material.SetFloat("_Fraction" + (i+1).ToString(), value: this.mole_frac);
+            rend.material.SetFloat("_Fraction" + (i+1).ToString(), value: mole_frac);
         }
 
         public void set_flowrate (int i, float flow_rate)
         {
             Renderer rend = this.GetComponent<Renderer>();
-            rend.material.SetFloat("_FlowRate" + (i+1).ToString(), value: this.flow_rate);
+            rend.material.SetFloat("_FlowRate" + (i+1).ToString(), value: flow_rate);
         }
 
         // Update is called once per frame

--- a/Assets/Scripts/UI/Structures/Reactor.cs
+++ b/Assets/Scripts/UI/Structures/Reactor.cs
@@ -20,11 +20,18 @@ namespace Rochester.ARTable.Structures
             Renderer rend = this.GetComponent<Renderer>();
             rend.material.shader = Shader.Find("Custom/WedgeCircle");
             rend.material.SetInt("_NumWedges", 5); //default to 4 species, in quarters
+            // "_Fraction#" for the mole fractions.
             rend.material.SetFloat("_Fraction1", 0.0f);
             rend.material.SetFloat("_Fraction2", 0.0f);
             rend.material.SetFloat("_Fraction3", 0.0f);
             rend.material.SetFloat("_Fraction4", 0.0f);
             rend.material.SetFloat("_Fraction5", 1.0f);
+            // "_FlowRate#" for the molar flow rates.
+            rend.material.SetFloat("_FlowRate1", 0.0f);
+            rend.material.SetFloat("_FlowRate2", 0.0f);
+            rend.material.SetFloat("_FlowRate3", 0.0f);
+            rend.material.SetFloat("_FlowRate4", 0.0f);
+            rend.material.SetFloat("_FlowRate5", 1.0f);
             GameObject temperatureValue = GameObject.Find("Backend/ColorKey/TemperatureValue");
             Transform temp_canvas = this.gameObject.transform.GetChild(1).GetChild(0);
             temp_canvas.GetComponent<Text>().text = temperatureValue.GetComponent<Text>().text;//default to currently-displayed temperature -- should actually only need this?
@@ -48,16 +55,21 @@ namespace Rochester.ARTable.Structures
             float prev_frac = 1;
             float next_frac = 1;
             float offset = Mathf.PI;//need to add half a circle to rendre in right place
-            float[] flow_rates = new float[num_wedges];//to store the raw numbers for flow rates
+            float[] flow_rates = new float[num_wedges];//to store the raw numbers for molar flow rate
             float flow_rate_sum = (float) 0.0;
+            float[] mole_frac = new float[num_wedges];
+            float mole_frac_sum = (float) 0.0;
             for(int i =0; i < num_wedges; i++){
-                flow_rates[i] = rend.material.GetFloat("_Fraction" + (i + 1).ToString());
-                flow_rate_sum += flow_rates[i];
+                mole_frac[i] = rend.material.GetFloat("_Fraction" + (i + 1).ToString());
+                mole_frac_sum += mole_frac[i];
+                
+                flow_rates[i] = rend.material.GetFloat("_FlowRate" + (i+1).ToString());
+                flow_rate_sum += flow_rates[i]
             }
             for(int i = 0; i < num_wedges; i++)
             {
                 offset = Mathf.PI;
-                frac = flow_rates[i] / flow_rate_sum;
+                frac = mole_frac[i] / mole_frac_sum;
                 sum += frac/(float)2.0;//get this center
                 if(prev_frac *100 < 3.0 && frac * 100 < 3.0)
                 {
@@ -65,7 +77,7 @@ namespace Rochester.ARTable.Structures
                 }
                 if(i < num_wedges - 1)
                 {
-                    next_frac = flow_rates[i+1] / flow_rate_sum;
+                    next_frac = mole_frac[i+1] / mole_frac_sum;
                 }
                 if(frac * 100 < 3.0 && next_frac * 100 < 3.0)
                 {

--- a/Assets/Scripts/UI/Structures/Reactor.cs
+++ b/Assets/Scripts/UI/Structures/Reactor.cs
@@ -42,6 +42,16 @@ namespace Rochester.ARTable.Structures
             temperature = temp;
         }
 
+        public void set_molefrac(int i, float mole_frac)
+        {
+            rend.material.SetFloat("_Fraction" + (i+1).ToString(), value: this.mole_frac)
+        }
+
+        public void set_flowrate (int i, float flow_rate)
+        {
+            rend.material.SetFloat("_FlowRate" + (i+1).ToString(), value: this.flow_rate)
+        }
+
         // Update is called once per frame
         void Update()
         {

--- a/Assets/Scripts/UI/Structures/Reactor.cs
+++ b/Assets/Scripts/UI/Structures/Reactor.cs
@@ -31,7 +31,7 @@ namespace Rochester.ARTable.Structures
             rend.material.SetFloat("_FlowRate2", 0.0f);
             rend.material.SetFloat("_FlowRate3", 0.0f);
             rend.material.SetFloat("_FlowRate4", 0.0f);
-            rend.material.SetFloat("_FlowRate5", 1.0f);
+            rend.material.SetFloat("_FlowRate5", 0.0f);
             GameObject temperatureValue = GameObject.Find("Backend/ColorKey/TemperatureValue");
             Transform temp_canvas = this.gameObject.transform.GetChild(1).GetChild(0);
             temp_canvas.GetComponent<Text>().text = temperatureValue.GetComponent<Text>().text;//default to currently-displayed temperature -- should actually only need this?
@@ -58,10 +58,8 @@ namespace Rochester.ARTable.Structures
             float[] flow_rates = new float[num_wedges];//to store the raw numbers for molar flow rate
             float flow_rate_sum = (float) 0.0;
             float[] mole_frac = new float[num_wedges];
-            float mole_frac_sum = (float) 0.0;
             for(int i =0; i < num_wedges; i++){
                 mole_frac[i] = rend.material.GetFloat("_Fraction" + (i + 1).ToString());
-                mole_frac_sum += mole_frac[i];
                 
                 flow_rates[i] = rend.material.GetFloat("_FlowRate" + (i+1).ToString());
                 flow_rate_sum += flow_rates[i]
@@ -69,7 +67,7 @@ namespace Rochester.ARTable.Structures
             for(int i = 0; i < num_wedges; i++)
             {
                 offset = Mathf.PI;
-                frac = mole_frac[i] / mole_frac_sum;
+                frac = mole_frac[i];
                 sum += frac/(float)2.0;//get this center
                 if(prev_frac *100 < 3.0 && frac * 100 < 3.0)
                 {
@@ -77,7 +75,7 @@ namespace Rochester.ARTable.Structures
                 }
                 if(i < num_wedges - 1)
                 {
-                    next_frac = mole_frac[i+1] / mole_frac_sum;
+                    next_frac = mole_frac[i+1];
                 }
                 if(frac * 100 < 3.0 && next_frac * 100 < 3.0)
                 {

--- a/Assets/Scripts/UI/Structures/Reactor.cs
+++ b/Assets/Scripts/UI/Structures/Reactor.cs
@@ -62,7 +62,7 @@ namespace Rochester.ARTable.Structures
                 mole_frac[i] = rend.material.GetFloat("_Fraction" + (i + 1).ToString());
                 
                 flow_rates[i] = rend.material.GetFloat("_FlowRate" + (i+1).ToString());
-                flow_rate_sum += flow_rates[i]
+                flow_rate_sum += flow_rates[i];
             }
             for(int i = 0; i < num_wedges; i++)
             {

--- a/Assets/Scripts/UI/Structures/Reactor.cs
+++ b/Assets/Scripts/UI/Structures/Reactor.cs
@@ -52,6 +52,11 @@ namespace Rochester.ARTable.Structures
             rend.material.SetFloat("_FlowRate" + (i+1).ToString(), value: flow_rate);
         }
 
+        public void set_numwedges(Renderer rend, int num)
+        {
+            rend.material.SetInt("_NumWedges", value: num);
+        }
+
         // Update is called once per frame
         void Update()
         {

--- a/Assets/Scripts/UI/Structures/Reactor.cs
+++ b/Assets/Scripts/UI/Structures/Reactor.cs
@@ -44,12 +44,14 @@ namespace Rochester.ARTable.Structures
 
         public void set_molefrac(int i, float mole_frac)
         {
-            rend.material.SetFloat("_Fraction" + (i+1).ToString(), value: this.mole_frac)
+            Renderer rend = this.GetComponent<Renderer>();
+            rend.material.SetFloat("_Fraction" + (i+1).ToString(), value: this.mole_frac);
         }
 
         public void set_flowrate (int i, float flow_rate)
         {
-            rend.material.SetFloat("_FlowRate" + (i+1).ToString(), value: this.flow_rate)
+            Renderer rend = this.GetComponent<Renderer>();
+            rend.material.SetFloat("_FlowRate" + (i+1).ToString(), value: this.flow_rate);
         }
 
         // Update is called once per frame

--- a/Python/kinetics_pb2.py
+++ b/Python/kinetics_pb2.py
@@ -19,7 +19,7 @@ DESCRIPTOR = _descriptor.FileDescriptor(
   name='kinetics.proto',
   package='reactors',
   syntax='proto3',
-  serialized_pb=_b('\n\x0ekinetics.proto\x12\x08reactors\"\x9d\x01\n\x0fReactorKinetics\x12\x13\n\x0btemperature\x18\x01 \x01(\x02\x12\x10\n\x08pressure\x18\x02 \x01(\x02\x12\r\n\x05label\x18\x03 \x01(\t\x12\n\n\x02id\x18\x04 \x01(\x05\x12\x15\n\rmole_fraction\x18\x05 \x03(\x02\x12\x18\n\x10\x63hemical_species\x18\x06 \x03(\t\x12\x17\n\x0fmolar_flow_rate\x18\x07 \x03(\x02\"K\n\x0eSystemKinetics\x12\x0c\n\x04time\x18\x01 \x01(\x03\x12+\n\x08kinetics\x18\x02 \x03(\x0b\x32\x19.reactors.ReactorKineticsB\"\xaa\x02\x1fRochester.Physics.Communicationb\x06proto3')
+  serialized_pb=_b('\n\x0ekinetics.proto\x12\x08reactors\"\x83\x01\n\x0fReactorKinetics\x12\x13\n\x0btemperature\x18\x01 \x01(\x02\x12\x10\n\x08pressure\x18\x02 \x01(\x02\x12\r\n\x05label\x18\x03 \x01(\t\x12\n\n\x02id\x18\x04 \x01(\x05\x12\x15\n\rmole_fraction\x18\x05 \x03(\x02\x12\x17\n\x0fmolar_flow_rate\x18\x06 \x03(\x02\"e\n\x0eSystemKinetics\x12\x0c\n\x04time\x18\x01 \x01(\x03\x12\x18\n\x10\x63hemical_species\x18\x02 \x03(\t\x12+\n\x08kinetics\x18\x03 \x03(\x0b\x32\x19.reactors.ReactorKineticsB\"\xaa\x02\x1fRochester.Physics.Communicationb\x06proto3')
 )
 
 
@@ -68,15 +68,8 @@ _REACTORKINETICS = _descriptor.Descriptor(
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='chemical_species', full_name='reactors.ReactorKinetics.chemical_species', index=5,
-      number=6, type=9, cpp_type=9, label=3,
-      has_default_value=False, default_value=[],
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      options=None),
-    _descriptor.FieldDescriptor(
-      name='molar_flow_rate', full_name='reactors.ReactorKinetics.molar_flow_rate', index=6,
-      number=7, type=2, cpp_type=6, label=3,
+      name='molar_flow_rate', full_name='reactors.ReactorKinetics.molar_flow_rate', index=5,
+      number=6, type=2, cpp_type=6, label=3,
       has_default_value=False, default_value=[],
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
@@ -94,7 +87,7 @@ _REACTORKINETICS = _descriptor.Descriptor(
   oneofs=[
   ],
   serialized_start=29,
-  serialized_end=186,
+  serialized_end=160,
 )
 
 
@@ -113,8 +106,15 @@ _SYSTEMKINETICS = _descriptor.Descriptor(
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='kinetics', full_name='reactors.SystemKinetics.kinetics', index=1,
-      number=2, type=11, cpp_type=10, label=3,
+      name='chemical_species', full_name='reactors.SystemKinetics.chemical_species', index=1,
+      number=2, type=9, cpp_type=9, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None),
+    _descriptor.FieldDescriptor(
+      name='kinetics', full_name='reactors.SystemKinetics.kinetics', index=2,
+      number=3, type=11, cpp_type=10, label=3,
       has_default_value=False, default_value=[],
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
@@ -131,7 +131,7 @@ _SYSTEMKINETICS = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=188,
+  serialized_start=162,
   serialized_end=263,
 )
 

--- a/Python/protobufs/kinetics_pb2.py
+++ b/Python/protobufs/kinetics_pb2.py
@@ -19,7 +19,7 @@ DESCRIPTOR = _descriptor.FileDescriptor(
   name='kinetics.proto',
   package='reactors',
   syntax='proto3',
-  serialized_pb=_b('\n\x0ekinetics.proto\x12\x08reactors\"\x9d\x01\n\x0fReactorKinetics\x12\x13\n\x0btemperature\x18\x01 \x01(\x02\x12\x10\n\x08pressure\x18\x02 \x01(\x02\x12\r\n\x05label\x18\x03 \x01(\t\x12\n\n\x02id\x18\x04 \x01(\x05\x12\x15\n\rmole_fraction\x18\x05 \x03(\x02\x12\x18\n\x10\x63hemical_species\x18\x06 \x03(\t\x12\x17\n\x0fmolar_flow_rate\x18\x07 \x03(\x02\"K\n\x0eSystemKinetics\x12\x0c\n\x04time\x18\x01 \x01(\x03\x12+\n\x08kinetics\x18\x02 \x03(\x0b\x32\x19.reactors.ReactorKineticsB\"\xaa\x02\x1fRochester.Physics.Communicationb\x06proto3')
+  serialized_pb=_b('\n\x0ekinetics.proto\x12\x08reactors\"\x83\x01\n\x0fReactorKinetics\x12\x13\n\x0btemperature\x18\x01 \x01(\x02\x12\x10\n\x08pressure\x18\x02 \x01(\x02\x12\r\n\x05label\x18\x03 \x01(\t\x12\n\n\x02id\x18\x04 \x01(\x05\x12\x15\n\rmole_fraction\x18\x05 \x03(\x02\x12\x17\n\x0fmolar_flow_rate\x18\x06 \x03(\x02\"e\n\x0eSystemKinetics\x12\x0c\n\x04time\x18\x01 \x01(\x03\x12\x18\n\x10\x63hemical_species\x18\x02 \x03(\t\x12+\n\x08kinetics\x18\x03 \x03(\x0b\x32\x19.reactors.ReactorKineticsB\"\xaa\x02\x1fRochester.Physics.Communicationb\x06proto3')
 )
 
 
@@ -68,15 +68,8 @@ _REACTORKINETICS = _descriptor.Descriptor(
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='chemical_species', full_name='reactors.ReactorKinetics.chemical_species', index=5,
-      number=6, type=9, cpp_type=9, label=3,
-      has_default_value=False, default_value=[],
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      options=None),
-    _descriptor.FieldDescriptor(
-      name='molar_flow_rate', full_name='reactors.ReactorKinetics.molar_flow_rate', index=6,
-      number=7, type=2, cpp_type=6, label=3,
+      name='molar_flow_rate', full_name='reactors.ReactorKinetics.molar_flow_rate', index=5,
+      number=6, type=2, cpp_type=6, label=3,
       has_default_value=False, default_value=[],
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
@@ -94,7 +87,7 @@ _REACTORKINETICS = _descriptor.Descriptor(
   oneofs=[
   ],
   serialized_start=29,
-  serialized_end=186,
+  serialized_end=160,
 )
 
 
@@ -113,8 +106,15 @@ _SYSTEMKINETICS = _descriptor.Descriptor(
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='kinetics', full_name='reactors.SystemKinetics.kinetics', index=1,
-      number=2, type=11, cpp_type=10, label=3,
+      name='chemical_species', full_name='reactors.SystemKinetics.chemical_species', index=1,
+      number=2, type=9, cpp_type=9, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None),
+    _descriptor.FieldDescriptor(
+      name='kinetics', full_name='reactors.SystemKinetics.kinetics', index=2,
+      number=3, type=11, cpp_type=10, label=3,
       has_default_value=False, default_value=[],
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
@@ -131,7 +131,7 @@ _SYSTEMKINETICS = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=188,
+  serialized_start=162,
   serialized_end=263,
 )
 


### PR DESCRIPTION
This pull request is directed toward Issue #1 Revert Unity to Properly Use Mole Fractions Again.

Four new variables, "_FlowRates#", to the UI/Reactor.cs file were added and changed the mole fractions, not molar flow rates, to be used for the calculation of the wedges. Though the molar flow rate values is what remained as displayed. (See commit 0cba386).

Within the CommClient.cs file, the values for "_FlowRates#" were set equal to kinetics.Kinetics.MolarFlowRate. Additionally, a check for the mole fraction sum, 'sum <= 1.0' was inserted into a for loop to ensure that it's a valid value. (See commit d7679ea).